### PR TITLE
fix: the typo for youtube in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # generating-melodies-with-rnn-lstm
-Repo with code and slides for the "Generating Melodies with RNN-LSTM" YouTuve series, by Valerio Velardo - The Sound of AI.
+Repo with code and slides for the "Generating Melodies with RNN-LSTM" YouTube series, by Valerio Velardo - The Sound of AI.
 
 Check out the series at:


### PR DESCRIPTION
This PR contains the changes in Readme file for fixing the spelling of youtube